### PR TITLE
Feature/add random food

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,4 +42,5 @@
     </main>
   </body>
   <script type="text/javascript" src="main.js"></script>
+  <script type="text/javascript" src="data.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,22 +18,18 @@
       <section class="whats-cooking">
         <h1>What are you looking for?<span>*</span></h1>
           <form>
-            <input type="radio" id="side">
-            <label for="side">Side</label><br><br>
-            <input type="radio" id="main-dish">
-            <label for="main-dish">Main Dish</label><br><br>
-            <input type="radio" id="dessert">
-            <label for="dessert">Dessert</label><br><br>
-            <input type="radio" id="entire-meal">
-            <label for="entire-meal">Entire Meal</label><br><br>
+            <input type="radio" name="group1" value="side" id="side"> Side</input><br><br>
+            <input type="radio" name="group1" value="main-dish" id="main-dish"> Main Dish</input><br><br>
+            <input type="radio" name="group1" value="dessert" id="dessert"> Dessert</input><br><br>
+            <!-- <input type="radio" name="group1" value="entire-meal" id="entire-meal"> Entire Meal</input><br><br> -->
             <button class="lets-cook" id="lets-cook">LET'S COOK</button>
           </form>
       </section>
       <section class="right-box">
-        <div class="cookpot hidden" id="cookpot-view">
-          <img src="./assets/cookpot.svg" class="cookpot-image"><br>
+        <div class="cookpot" id="cookpot-view">
+          <img src="./assets/cookpot.svg" class="cookpot-image" alt="vector image of cookpot"><br>
         </div>
-        <div class="form-output" id="you-should-make">
+        <div class="form-output hidden" id="you-should-make">
           <p><em>You should make:</em></p>
           <h1 class="output" id="form-output">Black Forest Cake!</h1>
           <button class="clear" id="clear">CLEAR</button>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,40 @@
+
+//right box displays a random dish from that array
+//cookpot icon disappears
+
+//////////// DOM ELEMENTS  ////////////
+var sideButton = document.querySelector('#side')
+var mainDishButton = document.querySelector('#main-dish')
+var dessertButton = document.querySelector('#dessert')
+//var entireMealButton = document.querySelector('#entire-meal')
+var letsCookButton = document.querySelector('#lets-cook')
+var cookpotView = document.querySelector('#cookpot-view')
+var youShouldMakeView = document.querySelector('#you-should-make')
+var formOutput = document.querySelector('#form-output')
+
+//////////// VARIABLES ////////////
+
+
+//////////// EVENT LISTENERS ////////////
+letsCookButton.addEventListener('click', displayRandomFood)
+
+//////////// FUNCTIONS AND EVENT HANDLERS ////////////
+function displayRandomFood() {
+  event.preventDefault();
+  cookpotView.classList.toggle('hidden');
+  youShouldMakeView.classList.toggle('hidden');
+  if(sideButton.checked=== true) {
+    var randomSide = randomFoods(sides);
+    formOutput.innerText = `${randomSide}!`
+  } else if (mainDishButton.checked === true){
+    var randomMain = randomFoods(mains)
+    formOutput.innerText = `${randomMain}!`
+  } else if (dessertButton.checked === true){
+    var randomDessert = randomFoods(desserts)
+    formOutput.innerText = `${randomDessert}!`
+  }
+}
+
+function randomFoods(foodType) {
+  return foodType[Math.floor(Math.random()*foodType.length)]
+}


### PR DESCRIPTION
Expected behavior:
When a user selects a dish option and then clicks the “Let’s Cook!” button, the user sees a random dish from the list of possible dishes for that category.
When the dish name appears, the cookpot icon disappears.

Bugs to squash:
Above behavior meets the MVP expectation but need to add clear button function to truly make it work.
Right now, your selection doesn't clear when you click "let's cook", and if you click "let's cook" a second time, you see the cookpot instead of a new recipe and have to click "let's cook" AGAIN to see a new recipe
